### PR TITLE
Trigger the build of the backend.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,12 @@ dependencies:
 general:
   artifacts:
     - ./coverage
+deployment:
+  master:
+    branch: master
+    commands:
+      - curl -v -X POST https://circleci.com/api/v1/project/WebJamApps/OurHandsAndFeetBackend/tree/master?circle-token=$TRIGGER_TOKEN
+  dev:
+    branch: dev
+    commands:
+      - curl -v -X POST https://circleci.com/api/v1/project/WebJamApps/OurHandsAndFeetBackend/tree/dev?circle-token=$TRIGGER_TOKEN


### PR DESCRIPTION
This can also be applied the same way to close WebJamApps/web-jam-back#9 Can go into CircleCI for the backend, go into Settings, scroll down to API Permissions, generate a token.  Copy that token, set as environment variable TRIGGER_TOKEN in the frontend, and then update the circle.yml with the proper URL for the build and branch.

What this does:
- Sets up a deployment section, which only runs after tests pass
- Since we have both dev and master branches, we can watch both branches, and make a curl call to the circle API to kick off a build for the appropriate backend job and branch.
